### PR TITLE
add find and search for signatures

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -32,6 +32,7 @@ There is also a [browserified](http://browserify.org/) version of this package a
 | Memberships         | search, change_permissions                    |
 | Roles               | search                                        |
 | Child Records       | search                                        |
+| Signatures          | find, search                                  |
 
 ### Usage
 

--- a/lib/api/signatures.js
+++ b/lib/api/signatures.js
@@ -1,0 +1,19 @@
+var _ = require('lodash');
+
+var mixins = require('./mixins/');
+var Base = require('./base');
+
+function Signatures () {
+  Base.apply(this, arguments);
+}
+
+Signatures.prototype = Object.create(Base.prototype);
+Signatures.prototype.constructor = Signatures;
+
+Signatures.prototype.resource = 'signatures';
+
+_.extend(Signatures.prototype,
+  mixins.findable,
+  mixins.searchable);
+
+module.exports = Signatures;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,7 +10,8 @@ var resources = {
   videos: require('./api/videos'),
   memberships: require('./api/memberships'),
   roles: require('./api/roles'),
-  child_records: require('./api/child_records')
+  child_records: require('./api/child_records'),
+  signatures: require('./api/signatures')
 };
 
 function Fulcrum(options) {

--- a/test/objects/signature.json
+++ b/test/objects/signature.json
@@ -1,0 +1,22 @@
+{
+  "signature": {
+    "access_key": "9855e3f2-85a5-4b9f-9e62-0b1bbcfef091",
+    "created_at": "2015-07-09T14:54:32Z",
+    "updated_at": "2015-07-09T14:54:32Z",
+    "uploaded": true,
+    "stored": true,
+    "processed": true,
+    "record_id": "215f4147-51b5-42bb-84af-06b8112d9ecf",
+    "form_id": "f99c0c14-7861-40b5-882c-d33fe2bcdeb2",
+    "file_size": 22826,
+    "content_type": "image/png",
+    "url": "https://api.fulcrumapp.com/api/v2/signatures/9855e3f2-85a5-4b9f-9e62-0b1bbcfef091",
+    "created_by": "Bryan McBride",
+    "created_by_id": "50633f84a934480d260001db",
+    "updated_by": "Bryan McBride",
+    "updated_by_id": "50633f84a934480d260001db",
+    "thumbnail": "https://fulcrumapp.s3.amazonaws.com/signatures/thumb_e063496f-3288-4d2b-ab54-2121e23de722-9855e3f2-85a5-4b9f-9e62-0b1bbcfef091.png",
+    "large": "https://fulcrumapp.s3.amazonaws.com/signatures/large_e063496f-3288-4d2b-ab54-2121e23de722-9855e3f2-85a5-4b9f-9e62-0b1bbcfef091.png",
+    "original": "https://fulcrumapp.s3.amazonaws.com/signatures/e063496f-3288-4d2b-ab54-2121e23de722-9855e3f2-85a5-4b9f-9e62-0b1bbcfef091.png"
+  }
+}

--- a/test/objects/signatures.json
+++ b/test/objects/signatures.json
@@ -1,0 +1,21 @@
+{
+  "current_page": 1,
+  "total_pages": 1,
+  "total_count": 446,
+  "per_page": 20000,
+  "signatures": [
+    {
+      "access_key": "9855e3f2-85a5-4b9f-9e62-0b1bbcfef091",
+      "created_at": "2015-07-09T14:54:32Z",
+      "updated_at": "2015-07-09T14:54:32Z",
+      "uploaded": true,
+      "stored": true,
+      "processed": true,
+      "record_id": "215f4147-51b5-42bb-84af-06b8112d9ecf",
+      "form_id": "f99c0c14-7861-40b5-882c-d33fe2bcdeb2",
+      "file_size": 22826,
+      "content_type": "image/png",
+      "url": "https://api.fulcrumapp.com/api/v2/signatures/9855e3f2-85a5-4b9f-9e62-0b1bbcfef091"
+    }
+  ]
+}

--- a/test/test_signatures.js
+++ b/test/test_signatures.js
@@ -1,0 +1,35 @@
+var assert = require('assert');
+var fs = require('fs');
+var nock = require('nock');
+
+var client = require('./client');
+
+describe('signatures', function(){
+
+  describe('#find()', function(){
+    it('should return a signature.', function(done){
+      var nocker = nock('https://api.fulcrumapp.com')
+                   .get('/api/v2/signatures/9855e3f2-85a5-4b9f-9e62-0b1bbcfef091')
+                   .replyWithFile(200, __dirname + '/objects/signature.json');
+      client.signatures.find('9855e3f2-85a5-4b9f-9e62-0b1bbcfef091', function(error, signature) {
+        assert.ifError(error);
+        assert.equal(signature.signature.content_type, 'image/png');
+        done();
+      });
+    });
+  });
+
+  describe('#search()', function(){
+    it('should return signatures.', function(done){
+      var nocker = nock('https://api.fulcrumapp.com')
+                   .get('/api/v2/signatures')
+                   .replyWithFile(200, __dirname + '/objects/signatures.json');
+      client.signatures.search({}, function(error, signatures) {
+        assert.ifError(error);
+        assert(signatures.signatures instanceof Array, 'signatures is not an array.');
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
I cannot say that I tested this extensively, but I was able to use ```search``` to download a bunch of signature files.  I ran ```find``` on a couple of specific ID's just to make sure it was working properly.  And the new tests pass.

Hope this helps.  I am not depending on this for any of our production applications FYI.

:beers: